### PR TITLE
Add alt stack

### DIFF
--- a/debug.go
+++ b/debug.go
@@ -291,6 +291,24 @@ scriptLoop:
 
 	tm.Println(box.String())
 
+	altstack := vm.GetAltStack()
+	if len(altstack) > 0 && !done && !fail {
+		tm.Println(tm.Background(tm.Color(tm.Bold("Alt Stack"), tm.WHITE), tm.MAGENTA))
+		var box *tm.Box
+		if done && !fail {
+			err = vm.CheckErrorCondition(true)
+			if err != nil {
+				done = false
+				fail = true
+			}
+		}
+		box = tm.NewBox(100|tm.PCT, len(vm.GetAltStack())+2, 0)
+		for i := len(altstack) - 1; i >= 0; i-- {
+			fmt.Fprintf(box, "%s\n", hex.EncodeToString(altstack[i]))
+		}
+		tm.Println(box.String())
+	}
+
 	tm.Printf("%s%s%s%s%s%s\n", "F3", tm.Background(tm.Color(tm.Bold("Step Back"), tm.WHITE), tm.CYAN), "F4", tm.Background(tm.Color(tm.Bold("Step Forward"), tm.WHITE), tm.CYAN), "ESC", tm.Background(tm.Color(tm.Bold("Quit"), tm.WHITE), tm.CYAN))
 	tm.Flush()
 


### PR DESCRIPTION
Minor update to display the alt stack when used.

Test with: 

`./meep debug --rpcserver=bchd-testnet.greyh.at:18335 --tx=0200000001128a97dd292612cc04ef2413dd0508f623f3480d940a7525633f1c8bb9f990b100000000f22102d72ae1867bbd32be1ad131b1a4248046d9291ca527275422ea60facf285e62d921022cf10549a4452deed1307c8e879a1ea8f21ba647d2652dbec075dce0b898f5cf00483045022100f1ded9c2d3c5e62fd08364fc4aadb5f95d2386f1086878e96eafa17247909c730220534dd193ca24ca374c521720d582cdec9a079f6f062efe799ab026630cc86904414c626b6b146e769bca089ab748cbc39a7eeab849ca3daa3efd1436b75711a6c2ca0f129ce038582660bb2202292974515293947600a06351937a6b67756874515293947600a06351937a6b6775686b76a96c88747a76a96c88747a6c6c51747a747a52aeffffffff01ed840100000000001976a914dafcba163f7ea9d56ef84e5ecae5c166402bdbc688ac00000000`